### PR TITLE
Change the directory Cm93 uses for the Sqlite DB.

### DIFF
--- a/Cm93.UI/App.config
+++ b/Cm93.UI/App.config
@@ -5,7 +5,7 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>
-    <add name="Cm93Context" connectionString="Data Source=|DataDirectory|Sqlite\Cm93.sqlite" providerName="System.Data.SQLite" />
+    <add name="Cm93Context" connectionString="Data Source=|DataDirectory|Cm93\Cm93.sqlite" providerName="System.Data.SQLite" />
   </connectionStrings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />

--- a/Cm93.UI/MefBootstrapper.cs
+++ b/Cm93.UI/MefBootstrapper.cs
@@ -56,6 +56,8 @@ namespace Cm93.UI
 			container.Compose(batch);
 
 			this.AppDispatcher = Dispatcher.CurrentDispatcher;
+
+			AppDomain.CurrentDomain.SetData("DataDirectory", Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
 		}
 
 		protected override object GetInstance(Type serviceType, string key)


### PR DESCRIPTION
This is an important change for making Cm93 a standalone application. As such I'll provide more detail so I can come back to it in several months time and understood what the hell went on.

"DataDirectory" is a property of the System.AppDomain class (of which there is a singleton default instance System.AppDomain.CurrentDomain). By default this property is the build directory e.g. .../bin/Debug/, where you find the DLLs and main executable.

The Cm93.sqlite database file is a static resource belonging to the Cm93.State project and is copied within the build directory to the relative path ./Sqlite/Cm93.sqlite. As such, App.config for the main executable specifies that the Sqlite file can be found in "Data Source=|DataDirectory|Sqlite\Cm93.sqlite".

This all works for local development, however, places the state of the database alongside the software itself. Most users will not have permission to update the database. The database should therefore be somewhere more appropriate, namely, the AppData directory. To do this two things are changed.

1. The definition of "DataDirectory" is altered to point to the AppData directory, rather than the build directory (see change in MefBootstrapper.cs).
2. The subdirectory containing Cm93.sqlite is renamed to Cm93 (see change in App.config).

This breaks a currently working automated step. The Cm93.sqlite file found in the Cm93.State project was always copied to the bin directory as part of the compilation process. The compilation process now no longer copies the database to the expected place (the AppData folder e.g. C:\Users\<user name>\AppData\Roaming\Cm93). The process is for the time being a manual one. In essence, the task of creating an AppData folder Cm93 and placing Cm93.sqlite inside it is one that is deferred for the installer.
